### PR TITLE
Verify user

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 // domain settings
 export const DOMAIN_NAME = process.env.DOMAIN_NAME;
 export const SERVER_PORT = 3000;
+export const FRONTEND_URL = process.env.FRONTEND_URL;
 
 // jwt settings
 export const JWT_SECRET = process.env.JWT_SECRET;

--- a/src/controller/UserController.ts
+++ b/src/controller/UserController.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, HttpStatus, Ip, Param, Post, Req, UnauthorizedException, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpStatus, Ip, Param, Post, Req, Res, UnauthorizedException, UseGuards } from '@nestjs/common';
 import {
   ChangePasswordDTO,
   CreateUserDTO,
@@ -11,6 +11,8 @@ import { UserMessage, generateUserMessage } from '../model/user/UserMessage';
 import { AuthService } from 'src/service/auth/AuthService';
 import { AuthGuard } from 'src/infra/security/AuthGuard';
 import { MailService } from 'src/service/mail/MailService';
+import { Response } from 'express';
+import { FRONTEND_URL } from 'src/constants';
 
 @Controller('user')
 export class UserController {
@@ -29,9 +31,9 @@ export class UserController {
   }
 
   @Get('/verify/:nickname/:uuid')
-  async verifyUser(@Param('nickname') nickname: string, @Param('uuid') uuid: string, @Ip() ip: string) {
+  async verifyUser(@Param('nickname') nickname: string, @Param('uuid') uuid: string, @Ip() ip: string, @Res() res: Response) {
     await this.userService.verifyUser(nickname, uuid, ip);
-    return generateUserMessage(UserMessage.SUCC_VERIFY_USER);
+    res.redirect(FRONTEND_URL);
   }
 
   @Post('/signin')

--- a/src/infra/mail/MailProcessor.ts
+++ b/src/infra/mail/MailProcessor.ts
@@ -1,7 +1,7 @@
 import { MailerService } from '@nestjs-modules/mailer';
 import { Processor, Process, OnQueueWaiting, OnGlobalQueueFailed } from '@nestjs/bull';
-import { Injectable } from '@nestjs/common';
 import { Job } from 'bull';
+import { FRONTEND_URL } from 'src/constants';
 
 @Processor('mail')
 export class MailProcessor {
@@ -10,7 +10,7 @@ export class MailProcessor {
   @Process('sendMail')
   async sendEmail(job: Job<{ email: string; name: string; code: string }>) {
     const { email, name, code } = job.data;
-    const url = `/user/verify/${name}/${code}`;
+    const url = `${FRONTEND_URL}/user/verify/${name}/${code}`;
     await this.mailerService.sendMail({
       to: email,
       subject: '[모션 테트리스] 가입을 축하합니다.',

--- a/src/service/auth/AuthService.ts
+++ b/src/service/auth/AuthService.ts
@@ -24,6 +24,8 @@ export class AuthService {
 
     const payload = { sub: user.nickname, ip: ip };
     return {
+      nickname: user.nickname,
+      email: user.email,
       access_token: await this.jwtService.signAsync(payload),
     };
   }

--- a/src/service/user/UserService.ts
+++ b/src/service/user/UserService.ts
@@ -29,11 +29,7 @@ export class UserService {
     if (user.verifyCode !== uuid) {
       throw new UnauthorizedException();
     }
-
-    if (user.signUpIp !== ip) {
-      throw new UnauthorizedException();
-    }
-
+    
     user.verified = true;
     user.signUpIp = undefined;
     await this.userRepository.save(user);


### PR DESCRIPTION
1. 이제부터 유저 인증 이메일을 보낼 때 완전한 형태의 이메일(Full URL)을 보냅니다.
2. 회원 가입을 하지 않은 다른 아이피에서도 유저 인증을 수행할 수 있습니다.
3. 이제 유저 인증이 완료되면 자동으로 프론트엔드 서버로 리다이렉트합니다.
4. 로그인 시 닉네임과 이메일을 동시에 보냅니다. 